### PR TITLE
Support loading data from /usr/share/cdn-definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Added
+
+- Support loading data from `/usr/share/cdn-definitions`
 
 ## [0.1.1] - 2020-03-24
 

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -49,9 +49,13 @@ the ``cdn_definitions`` module, as in example:
       # my path falls under a /rhui/ alias,
       # so now do something special
 
-The library will use its own bundled data.
-To ensure the most up-to-date definitions, upgrade the
-package from PyPI.
+The library will use data from the first existing of the following sources:
+
+- A JSON file pointed at by the ``CDN_DEFINITIONS_PATH`` environment variable.
+- The file bundled with the library on PyPI.
+- ``/usr/share/cdn-definitions/data.json``.
+
+To ensure the most up-to-date definitions, upgrade the package from PyPI.
 
 
 Python reference

--- a/src/cdn_definitions/_impl/__init__.py
+++ b/src/cdn_definitions/_impl/__init__.py
@@ -1,8 +1,23 @@
 import json
 import os
 
-JSON_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data.json")
-DATA = json.load(open(JSON_PATH))
+
+def load_data():
+    # Load data from first existing of these
+    candidate_paths = [
+        os.path.join(os.path.dirname(os.path.dirname(__file__)), "data.json"),
+        "/usr/share/cdn-definitions/data.json",
+    ]
+
+    # If env var is set, it takes highest precedence
+    if "CDN_DEFINITIONS_PATH" in os.environ:
+        candidate_paths.insert(0, os.environ["CDN_DEFINITIONS_PATH"])
+
+    existing_paths = [p for p in candidate_paths if os.path.exists(p)]
+    return json.load(open(existing_paths[0]))
+
+
+DATA = load_data()
 
 
 class PathAlias(object):

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,0 +1,13 @@
+from cdn_definitions._impl import load_data
+
+
+def test_can_load_custom_data(monkeypatch, tmpdir):
+    json_file = tmpdir.join("myfile.json")
+    json_file.write('{"hello": "world"}')
+
+    # If we set an env var pointing at the above JSON file, the library
+    # should load it instead of the bundled data
+    monkeypatch.setenv("CDN_DEFINITIONS_PATH", str(json_file))
+    data = load_data()
+
+    assert data == {"hello": "world"}


### PR DESCRIPTION
This will be used by the cdn-definitions RPM package.
Load path can also be customized via CDN_DEFINITIONS_PATH env var.