### PR TITLE
RHUI: drop /content/fastrack/rhel/rhui alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Removed
+
+- Dropped an incorrect fastrack RHUI alias
 
 ## [0.2.0] - 2020-03-24
 

--- a/src/cdn_definitions/data.json
+++ b/src/cdn_definitions/data.json
@@ -71,10 +71,6 @@
             "src": "/content/eus/rhel/rhui"
         },
         {
-            "dest": "/content/fastrack/rhel",
-            "src": "/content/fastrack/rhel/rhui"
-        },
-        {
             "dest": "/content/rc/rhel",
             "src": "/content/rc/rhel/rhui"
         }

--- a/src/cdn_definitions/data.yaml
+++ b/src/cdn_definitions/data.yaml
@@ -57,9 +57,6 @@ rhui_alias:
 - src: /content/eus/rhel/rhui
   dest: /content/eus/rhel
 
-- src: /content/fastrack/rhel/rhui
-  dest: /content/fastrack/rhel
-
 - src: /content/rc/rhel/rhui
   dest: /content/rc/rhel
 


### PR DESCRIPTION
I've gone through and checked all RHUI aliases against actual
data on CDN. This one seems to be incorrect:

1. on current CDN filesystem, the rhui path doesn't exist at all
2. on older filesystem, it exists, but is not symlinked to non-rhui
3. on older filesystem, content between rhui and non-rhui paths
   doesn't appear to be identical
4. the relevant content sets were disabled in 2014 (rcm-metadata
   ec3025f411e46c)

Hence this is not actually a valid RHUI alias.  It was probably
intended to be, so an argument could be made for keeping it, but
it would force us to change point (3) above and start serving
identical content for the two paths, and there's not really any
benefit to making such a change now, only risk.