### PR TITLE
docs: fix outdated reference to cdn-lambda

### DIFF
--- a/docs/maint.rst
+++ b/docs/maint.rst
@@ -100,7 +100,7 @@ Downstream projects
 Some known or expected uses of this dataset from downstream projects are listed here.
 Be aware that changes to the dataset may require updates to packages for these projects.
 
-  **cdn-lambda**
+  **exodus-lambda**
     - Uses RHUI and origin aliases when resolving requests to the CDN.
 
   **engproduct-cli**


### PR DESCRIPTION
That project was renamed to exodus-lambda.