### PR TITLE
Add RHEL 8 E4S link for RHUI

### DIFF
--- a/scripts/make-json
+++ b/scripts/make-json
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import os
 import sys
 import yaml

--- a/src/cdn_definitions/data.json
+++ b/src/cdn_definitions/data.json
@@ -59,6 +59,10 @@
             "src": "/content/dist/rhs/rhui"
         },
         {
+            "dest": "/content/e4s/rhel8",
+            "src": "/content/e4s/rhel8/rhui"
+        },
+        {
             "dest": "/content/e4s/rhel",
             "src": "/content/e4s/rhel/rhui"
         },

--- a/src/cdn_definitions/data.yaml
+++ b/src/cdn_definitions/data.yaml
@@ -48,6 +48,9 @@ rhui_alias:
 - src: /content/dist/rhs/rhui
   dest: /content/dist/rhs
 
+- src: /content/e4s/rhel8/rhui
+  dest: /content/e4s/rhel8
+
 - src: /content/e4s/rhel/rhui
   dest: /content/e4s/rhel
 


### PR DESCRIPTION
Currently, no RHEL 8 E4S content is available on RHUI, but it is needed for the same reasons that RHEL 7 E4S content is available.

Also included in this PR is a patch that I needed in order to follow the (excellent and thorough) contribution guide.