### PR TITLE
Add RHEL 8 EUS link for RHUI

### DIFF
--- a/src/cdn_definitions/data.json
+++ b/src/cdn_definitions/data.json
@@ -71,6 +71,10 @@
             "src": "/content/els/rhel/rhui"
         },
         {
+            "dest": "/content/eus/rhel8",
+            "src": "/content/eus/rhel8/rhui"
+        },
+        {
             "dest": "/content/eus/rhel",
             "src": "/content/eus/rhel/rhui"
         },

--- a/src/cdn_definitions/data.yaml
+++ b/src/cdn_definitions/data.yaml
@@ -57,6 +57,9 @@ rhui_alias:
 - src: /content/els/rhel/rhui
   dest: /content/els/rhel
 
+- src: /content/eus/rhel8/rhui
+  dest: /content/eus/rhel8
+
 - src: /content/eus/rhel/rhui
   dest: /content/eus/rhel
 


### PR DESCRIPTION
Currently, no RHEL 8 EUS content is available on RHUI, but it is needed
for the same reasons that RHEL 7 EUS content is available.