### PR TITLE
Add RHEL 8 AUS link for RHUI

### DIFF
--- a/src/cdn_definitions/data.json
+++ b/src/cdn_definitions/data.json
@@ -11,6 +11,10 @@
     ],
     "rhui_alias": [
         {
+            "dest": "/content/aus/rhel8",
+            "src": "/content/aus/rhel8/rhui"
+        },
+        {
             "dest": "/content/aus/rhel",
             "src": "/content/aus/rhel/rhui"
         },

--- a/src/cdn_definitions/data.yaml
+++ b/src/cdn_definitions/data.yaml
@@ -12,6 +12,9 @@ version: "1.0.0"
 # For some of these aliases, certain content is filtered under the /rhui/ paths
 # (mainly architectures). This is currently not expressed in the dataset here.
 rhui_alias:
+- src: /content/aus/rhel8/rhui
+  dest: /content/aus/rhel8
+
 - src: /content/aus/rhel/rhui
   dest: /content/aus/rhel
 


### PR DESCRIPTION
Currently, no RHEL 8 AUS content is available on RHUI, but it is needed
for the same reasons that RHEL 7 AUS content is available.