### PR TITLE
Create cdn_definitions.api module [RHELDST-4862]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/src/cdn_definitions/__init__.py
+++ b/src/cdn_definitions/__init__.py
@@ -1,3 +1,3 @@
-from ._impl import PathAlias, origin_aliases, rhui_aliases
+from ._impl import PathAlias, origin_aliases, rhui_aliases, load_data
 
-__all__ = ["PathAlias", "origin_aliases", "rhui_aliases"]
+__all__ = ["PathAlias", "origin_aliases", "rhui_aliases", "load_data"]

--- a/src/cdn_definitions/api/__init__.py
+++ b/src/cdn_definitions/api/__init__.py
@@ -1,0 +1,14 @@
+import os
+import json
+from .. import load_data
+
+
+def schema():
+    with open(
+        os.path.join(os.path.dirname(os.path.dirname(__file__)), "schema.json")
+    ) as f:
+        return json.load(f)
+
+
+def data(source=None):
+    return load_data(source)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 pytest
 jsonschema
 PyYAML
+mock

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,25 @@
+import json
+import os
+
+from cdn_definitions import api
+
+
+def test_load_schema_api():
+    schema = api.schema()
+    with open(
+        os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            "src",
+            "cdn_definitions",
+            "schema.json",
+        )
+    ) as f:
+        local_schema = json.load(f)
+    assert schema == local_schema
+
+
+def test_load_data_api(tmpdir):
+    json_file = tmpdir.join("myfile.json")
+    json_file.write('{"hello": "world"}')
+    data = api.data(source=str(json_file))
+    assert data == {"hello": "world"}

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,4 +1,7 @@
 from cdn_definitions._impl import load_data
+from mock import patch
+import pytest
+import requests
 
 
 def test_can_load_custom_data(monkeypatch, tmpdir):
@@ -11,3 +14,35 @@ def test_can_load_custom_data(monkeypatch, tmpdir):
     data = load_data()
 
     assert data == {"hello": "world"}
+
+
+def test_can_load_custom_data_from_source(monkeypatch, tmpdir):
+    json_file = tmpdir.join("myfile.json")
+    json_file.write('{"hello": "world"}')
+
+    # If we set an env var pointing at the above JSON file, the library
+    # should load it instead of the bundled data
+    data = load_data(source=str(json_file))
+
+    assert data == {"hello": "world"}
+
+
+def test_can_load_url_from_env_var(monkeypatch):
+    with patch("cdn_definitions._impl.requests.get") as r:
+        r.return_value = {"hello": "world"}
+        monkeypatch.setenv("CDN_DEFINITIONS_PATH", "https://example")
+        data = load_data()
+    assert data == {"hello": "world"}
+
+
+def test_can_load_url_from_source_arg(monkeypatch):
+    with patch("cdn_definitions._impl.requests.get") as r:
+        r.return_value = {"hello": "world"}
+        data = load_data("https://example.com")
+
+    assert data == {"hello": "world"}
+
+
+def test_invalid_source(monkeypatch, tmpdir):
+    with pytest.raises(RuntimeError, match="Could not load data"):
+        data = load_data(source="test")

--- a/tox.ini
+++ b/tox.ini
@@ -2,12 +2,15 @@
 envlist = py27,py38,static,docs
 
 [testenv]
-deps=-rtest-requirements.txt
+deps=
+        -rrequirements.txt
+        -rtest-requirements.txt
 commands=pytest -v {posargs}
 whitelist_externals=sh
 
 [testenv:static]
 deps=
+        -rrequirements.txt
 	-rtest-requirements.txt
 	black
 	pylint
@@ -17,6 +20,7 @@ commands=
 
 [testenv:cov]
 deps=
+        -rrequirements.txt
 	-rtest-requirements.txt
 	pytest-cov
 usedevelop=true
@@ -26,6 +30,7 @@ commands=
 [testenv:cov-travis]
 passenv = TRAVIS TRAVIS_*
 deps=
+        -rrequirements.txt
 	-rtest-requirements.txt
 	pytest-cov
 	coveralls


### PR DESCRIPTION
The cdn_definitions.api module allows clients to consume the
data.json or the schema.json files via a convenient API.

This commit also introduces an optional "source" argument to the
data_loads method. The source argument allows the user to specify
the source of the cdn_definitions data.json file. The source could
be a URL or a local path on a directory tree. If a source is not
specified, the location may be overriden via the
CDN_DEFINITIONS_PATH environment variable, which also may either
be in the form of a URL or a local path.