### PR TITLE
pyrsistent install fails on py2.7

### DIFF
--- a/constraints-legacy.txt
+++ b/constraints-legacy.txt
@@ -1,0 +1,3 @@
+# Oldest supported versions of major libraries can be added to this
+# file. They'll be tested with Python 2.7.
+pyrsistent==0.16.1

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,11 @@ deps=-rtest-requirements.txt
 commands=pytest -v {posargs}
 whitelist_externals=sh
 
+[testenv:py27]
+deps=
+	-cconstraints-legacy.txt
+	-rtest-requirements.txt
+
 [testenv:static]
 deps=
 	-rtest-requirements.txt


### PR DESCRIPTION
The python2.7 installation of pyresistent (a jsonschema dependency)
fails with the following error message:

"pyrsistent requires Python '>=3.5' but the running Python is 2.7.15"

Pyrsistent reportedly dropped python2.7 support [1]. Py2.7 installs
of jsonschema must pin the latest pyresistent version with python2.7
support (pyrsistent-0.16.1) to avoid an installation error.

[1] https://github.com/tobgu/pyrsistent/issues/208