### PR TITLE
Add requirements.txt as a dependency of py27 tox env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ whitelist_externals=sh
 
 [testenv:py27]
 deps=
+        -rrequirements.txt
 	-cconstraints-legacy.txt
 	-rtest-requirements.txt
 


### PR DESCRIPTION
The commit which moved PyYAML from test-requirements.txt into a
newly created requirements.txt file (44045c5), was developed in
parallel with the commit which specified the py27 tox environment's
dependencies (a2aba3c). As such, the py27 tox environment's
dependencies did not include requirements.txt. This resulted in the
exclusion of PyYAML from the py27 tox environment.
