### PR TITLE
Create RHUI symlinks for RHEL-9 beta, dist, eus, e4s, aus

### DIFF
--- a/src/cdn_definitions/data.json
+++ b/src/cdn_definitions/data.json
@@ -15,12 +15,20 @@
             "src": "/content/aus/rhel8/rhui"
         },
         {
+            "dest": "/content/aus/rhel9",
+            "src": "/content/aus/rhel9/rhui"
+        },
+        {
             "dest": "/content/aus/rhel",
             "src": "/content/aus/rhel/rhui"
         },
         {
             "dest": "/content/beta/rhel8",
             "src": "/content/beta/rhel8/rhui"
+        },
+        {
+            "dest": "/content/beta/rhel9",
+            "src": "/content/beta/rhel9/rhui"
         },
         {
             "dest": "/content/beta/rhel-alt",
@@ -47,6 +55,10 @@
             "src": "/content/dist/rhel8/rhui"
         },
         {
+            "dest": "/content/dist/rhel9",
+            "src": "/content/dist/rhel9/rhui"
+        },
+        {
             "dest": "/content/dist/rhel-alt",
             "src": "/content/dist/rhel-alt/rhui"
         },
@@ -67,6 +79,10 @@
             "src": "/content/e4s/rhel8/rhui"
         },
         {
+            "dest": "/content/e4s/rhel9",
+            "src": "/content/e4s/rhel9/rhui"
+        },
+        {
             "dest": "/content/e4s/rhel",
             "src": "/content/e4s/rhel/rhui"
         },
@@ -77,6 +93,10 @@
         {
             "dest": "/content/eus/rhel8",
             "src": "/content/eus/rhel8/rhui"
+        },
+        {
+            "dest": "/content/eus/rhel9",
+            "src": "/content/eus/rhel9/rhui"
         },
         {
             "dest": "/content/eus/rhel",

--- a/src/cdn_definitions/data.yaml
+++ b/src/cdn_definitions/data.yaml
@@ -15,11 +15,17 @@ rhui_alias:
 - src: /content/aus/rhel8/rhui
   dest: /content/aus/rhel8
 
+- src: /content/aus/rhel9/rhui
+  dest: /content/aus/rhel9
+
 - src: /content/aus/rhel/rhui
   dest: /content/aus/rhel
 
 - src: /content/beta/rhel8/rhui
   dest: /content/beta/rhel8
+
+- src: /content/beta/rhel9/rhui
+  dest: /content/beta/rhel9
 
 - src: /content/beta/rhel-alt/rhui
   dest: /content/beta/rhel-alt
@@ -39,6 +45,9 @@ rhui_alias:
 - src: /content/dist/rhel8/rhui
   dest: /content/dist/rhel8
 
+- src: /content/dist/rhel9/rhui
+  dest: /content/dist/rhel9
+
 - src: /content/dist/rhel-alt/rhui
   dest: /content/dist/rhel-alt
 
@@ -54,6 +63,9 @@ rhui_alias:
 - src: /content/e4s/rhel8/rhui
   dest: /content/e4s/rhel8
 
+- src: /content/e4s/rhel9/rhui
+  dest: /content/e4s/rhel9
+
 - src: /content/e4s/rhel/rhui
   dest: /content/e4s/rhel
 
@@ -62,6 +74,9 @@ rhui_alias:
 
 - src: /content/eus/rhel8/rhui
   dest: /content/eus/rhel8
+
+- src: /content/eus/rhel9/rhui
+  dest: /content/eus/rhel9
 
 - src: /content/eus/rhel/rhui
   dest: /content/eus/rhel


### PR DESCRIPTION
RHEL-9 RHUI continues to be symlinked in the same way as RHEL-8 was.
Currently, there no update streams content available as we're still setting things up, but EUS and E4S is confirmed for RHEL 9.0