### PR TITLE
Fix requirements.txt not used

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.md
 include CHANGELOG.md
 include LICENSE
+include requirements.txt
 graft src

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,11 @@ def get_long_description():
     return text[idx:]
 
 
+def get_requirements():
+    with open("requirements.txt") as f:
+        return f.read().splitlines()
+
+
 setup(
     name="cdn-definitions",
     version="1.3.0",
@@ -27,6 +32,7 @@ setup(
     include_package_data=True,
     long_description=get_long_description(),
     long_description_content_type="text/markdown",
+    install_requires=get_requirements(),
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",


### PR DESCRIPTION
requirements.txt was introduced recently in 44045c557ea0b1c237.
However, this does not actually do anything during "pip install",
which only looks at install_requires metadata.

Here we copy the convention used from most of our other projects:
just reuse requirements.txt for install_requires. This ensures
"pip install cdn-definitions" will install dependencies.