### PR TITLE
cdn-definitions should only contain reference data [RHELDST-4701]

### DIFF
--- a/src/cdn_definitions/data.json
+++ b/src/cdn_definitions/data.json
@@ -35,12 +35,8 @@
     ],
     "origin_alias": [
         {
-            "dest": "/origin",
-            "src": "/content/origin"
-        },
-        {
-            "dest": "/origin/rpms",
-            "src": "/origin/rpm"
+            "dest": "/origin/examples",
+            "src": "/origin/example"
         }
     ],
     "override_initial_rhel_release": {
@@ -65,80 +61,8 @@
     },
     "rhui_alias": [
         {
-            "dest": "/content/aus/rhel8",
-            "src": "/content/aus/rhel8/rhui"
-        },
-        {
-            "dest": "/content/aus/rhel",
-            "src": "/content/aus/rhel/rhui"
-        },
-        {
-            "dest": "/content/beta/rhel8",
-            "src": "/content/beta/rhel8/rhui"
-        },
-        {
-            "dest": "/content/beta/rhel-alt",
-            "src": "/content/beta/rhel-alt/rhui"
-        },
-        {
-            "dest": "/content/beta/rhel",
-            "src": "/content/beta/rhel/rhui"
-        },
-        {
-            "dest": "/content/beta/rhs",
-            "src": "/content/beta/rhs/rhui"
-        },
-        {
-            "dest": "/content/dist/layered",
-            "src": "/content/dist/layered/rhui"
-        },
-        {
-            "dest": "/content/dist/middleware",
-            "src": "/content/dist/middleware/rhui"
-        },
-        {
-            "dest": "/content/dist/rhel8",
-            "src": "/content/dist/rhel8/rhui"
-        },
-        {
-            "dest": "/content/dist/rhel-alt",
-            "src": "/content/dist/rhel-alt/rhui"
-        },
-        {
-            "dest": "/content/dist/rhel",
-            "src": "/content/dist/rhel/rhui"
-        },
-        {
-            "dest": "/content/dist/rhes",
-            "src": "/content/dist/rhes/rhui"
-        },
-        {
-            "dest": "/content/dist/rhs",
-            "src": "/content/dist/rhs/rhui"
-        },
-        {
-            "dest": "/content/e4s/rhel8",
-            "src": "/content/e4s/rhel8/rhui"
-        },
-        {
-            "dest": "/content/e4s/rhel",
-            "src": "/content/e4s/rhel/rhui"
-        },
-        {
-            "dest": "/content/els/rhel",
-            "src": "/content/els/rhel/rhui"
-        },
-        {
-            "dest": "/content/eus/rhel8",
-            "src": "/content/eus/rhel8/rhui"
-        },
-        {
-            "dest": "/content/eus/rhel",
-            "src": "/content/eus/rhel/rhui"
-        },
-        {
-            "dest": "/content/rc/rhel",
-            "src": "/content/rc/rhel/rhui"
+            "dest": "/content/dist/rhel/X",
+            "src": "/content/dist/rhel/rhui/X"
         }
     ],
     "rhui_product_id": "000",
@@ -188,5 +112,5 @@
     "tps_variant_mappings": {
         "example-arch": "Example-Variant"
     },
-    "version": "1.1.0"
+    "version": "1.1.1"
 }

--- a/src/cdn_definitions/data.yaml
+++ b/src/cdn_definitions/data.yaml
@@ -1,7 +1,7 @@
 ---
 # Version of this data structure's format.
 # Version string is maintained in accordance with SemVer.
-version: "1.1.0"
+version: "1.1.1"
 
 # Aliases between paths used for consuming content under RHUI entitlements.
 #
@@ -12,86 +12,14 @@ version: "1.1.0"
 # For some of these aliases, certain content is filtered under the /rhui/ paths
 # (mainly architectures). This is currently not expressed in the dataset here.
 rhui_alias:
-- src: /content/aus/rhel8/rhui
-  dest: /content/aus/rhel8
-
-- src: /content/aus/rhel/rhui
-  dest: /content/aus/rhel
-
-- src: /content/beta/rhel8/rhui
-  dest: /content/beta/rhel8
-
-- src: /content/beta/rhel-alt/rhui
-  dest: /content/beta/rhel-alt
-
-- src: /content/beta/rhel/rhui
-  dest: /content/beta/rhel
-
-- src: /content/beta/rhs/rhui
-  dest: /content/beta/rhs
-
-- src: /content/dist/layered/rhui
-  dest: /content/dist/layered
-
-- src: /content/dist/middleware/rhui
-  dest: /content/dist/middleware
-
-- src: /content/dist/rhel8/rhui
-  dest: /content/dist/rhel8
-
-- src: /content/dist/rhel-alt/rhui
-  dest: /content/dist/rhel-alt
-
-- src: /content/dist/rhel/rhui
-  dest: /content/dist/rhel
-
-- src: /content/dist/rhes/rhui
-  dest: /content/dist/rhes
-
-- src: /content/dist/rhs/rhui
-  dest: /content/dist/rhs
-
-- src: /content/e4s/rhel8/rhui
-  dest: /content/e4s/rhel8
-
-- src: /content/e4s/rhel/rhui
-  dest: /content/e4s/rhel
-
-- src: /content/els/rhel/rhui
-  dest: /content/els/rhel
-
-- src: /content/eus/rhel8/rhui
-  dest: /content/eus/rhel8
-
-- src: /content/eus/rhel/rhui
-  dest: /content/eus/rhel
-
-- src: /content/rc/rhel/rhui
-  dest: /content/rc/rhel
+- src: /content/dist/rhel/rhui/X
+  dest: /content/dist/rhel/X
 
 
-# Aliases between paths relating to the origin area of CDN.
+# Aliases between paths relating to the origin area of CDN. Paths must begin with "/origin".
 origin_alias:
-
-# Top-level of origin is accessible also under "content".
-#
-# Original rationale: relative symlinks from Packages to origin were shared between rhui
-# and non-rhui repos, but paths for rhui repos are one level deeper than non-rhui repos.
-#
-# That means a relative link starting with a sequence of "../../.." reaching up to
-# /origin for a non-rhui repo would only reach up to /content/origin for a rhui repo;
-# hence for the same link to work in both cases, this alias must exist.
-- src: /content/origin
-  dest: /origin
-
-# "rpm" and "rpms" mean the same thing under origin.
-#
-# This was originally introduced due to a bug in publishing tools, where some code
-# was designed for "rpms" while other code was designed for "rpm". Rather than fixing
-# it properly, it was worked around by a symlink, and the workaround is now effectively
-# permanent.
-- src: /origin/rpm
-  dest: /origin/rpms
+- src: /origin/example
+  dest: /origin/examples
 
 
 # Content set prefixes which should be using symlinks at the $releasever level


### PR DESCRIPTION
Production ("live") data definitions should be reserved for
cdn-definitions-private.