### PR TITLE
Adding rhel_open_dist listing active RHEL versions 

### DIFF
--- a/src/cdn_definitions/data.json
+++ b/src/cdn_definitions/data.json
@@ -63,6 +63,9 @@
             "0.0"
         ]
     },
+    "rhel_open_dist": [
+        0
+    ],
     "rhui_alias": [
         {
             "dest": "/content/aus/rhel8",
@@ -188,5 +191,5 @@
     "tps_variant_mappings": {
         "example-arch": "Example-Variant"
     },
-    "version": "1.1.0"
+    "version": "1.2.0"
 }

--- a/src/cdn_definitions/data.yaml
+++ b/src/cdn_definitions/data.yaml
@@ -1,7 +1,7 @@
 ---
 # Version of this data structure's format.
 # Version string is maintained in accordance with SemVer.
-version: "1.1.0"
+version: "1.2.0"
 
 # Aliases between paths used for consuming content under RHUI entitlements.
 #
@@ -189,3 +189,8 @@ signing_keys_mappings:
 # A list of RHEL releasevers (minor versions) that should be excluded from listing files
 exclude_from_listings:
 - "0.0"
+
+# Major RHEL versions which are still expecting new minor releases in
+# future. Versions not listed here are exempt from various tooling.
+rhel_open_dist:
+- 0

--- a/src/cdn_definitions/schema.json
+++ b/src/cdn_definitions/schema.json
@@ -99,6 +99,13 @@
         "major_version": {
             "type": "integer"
         },
+        "major_version_list": {
+            "items": {
+                "$ref": "#/definitions/major_version"
+            },
+            "type": "array",
+            "uniqueItems": true
+        },
         "major_version_string": {
             "pattern": "^[0-9]+$",
             "type": "string"
@@ -263,6 +270,9 @@
         },
         "release_stream_mappings": {
             "$ref": "#/definitions/release_stream_mapping"
+        },
+        "rhel_open_dist": {
+            "$ref": "#/definitions/major_version_list"
         },
         "rhui_alias": {
             "$ref": "#/definitions/path_alias_list"

--- a/src/cdn_definitions/schema.yaml
+++ b/src/cdn_definitions/schema.yaml
@@ -27,6 +27,12 @@ definitions:
   major_version:
     type: integer
 
+  major_version_list:
+    type: array
+    items:
+      $ref: "#/definitions/major_version"
+    uniqueItems: true
+
   major_version_string:
     type: string
     pattern: "^[0-9]+$"
@@ -239,6 +245,9 @@ properties:
 
   signing_keys_mappings:
     $ref: "#/definitions/signing_keys_mapping"
+
+  rhel_open_dist:
+    $ref: "#/definitions/major_version_list"
 
   rhui_product_id:
     $ref: "#/definitions/product_id"


### PR DESCRIPTION
Adding rhel_open_dist that will return list of  RHEL major versions which are still expecting new minor releases

Refers to [RHELDST-2517]