### PR TITLE
Use urllib3.util.retry from requests.packages [RHELDST-5671]

### DIFF
--- a/src/cdn_definitions/_impl/__init__.py
+++ b/src/cdn_definitions/_impl/__init__.py
@@ -109,9 +109,8 @@ def load_schema():
     Returns:
         The cdn-definitions schema, coerced into a Python object.
     """
-    with open(
-        os.path.join(os.path.dirname(os.path.dirname(__file__)), "schema.json")
-    ) as schema:
+    schema_filename = os.path.join(os.path.dirname(__file__), "../schema.json")
+    with open(schema_filename) as schema:  # pylint: disable=unspecified-encoding
         return json.load(schema)
 
 

--- a/src/cdn_definitions/_impl/__init__.py
+++ b/src/cdn_definitions/_impl/__init__.py
@@ -4,7 +4,18 @@ import warnings
 
 import requests
 import yaml
-from urllib3.util.retry import Retry
+
+# Requests module historically (>=0.8.0) bundled its own urllib3,
+# however it may depend on how the module is installed, as some
+# distributions (e.g. RHEL-7) ship the same version of requests
+# module without bundled urllib3 and add a compat layer aliasing
+# requests.packages.urllib3 to non-bundled urllib3.
+# New versions (>=2.16) of the requests module stopped bundling
+# urllib3 and added a different backwards-compat layer to retain
+# requests.packages.* imports, however that layer is nontransparent
+# to static analyzers such as pylint, hence the disable=import-error
+# annotation even though the actual import still works.
+from requests.packages.urllib3.util.retry import Retry  # pylint: disable=import-error
 
 
 def parsed(data, ext):


### PR DESCRIPTION
Fixes
TypeError: unsupported operand type(s) for -=: 'Retry' and 'int'

Sufficiently new versions of requests module bundle its own urllib3,
which makes the whole Session-HTTPAdapter-Retry chain behave
unexpectedly. HTTPAdapter always calls Retry.from_int() regardless
of the max_retries parameter type. Retry.from_int() method either
creates a new instance of Retry or compares if the parameter already
is a Retry instance and returns it unchanged. The problem here is
that urllib3.util.retry.Retry is not the same as
requests.packages.urllib3.util.retry.Retry, so the non-bundled retry
object is wrapped into the bundled Retry object and is treated
as integer from then on, leading to the TypeError above.

RHEL-6 and RHEL-7 python-requests packages ship their own version of
requests.packages.urllib3.* which aliases the real top-level urllib3
module, so this code adjustment should work even on legacy systems
without urllib3 bundled with requests.