### PR TITLE
Drop ineffective requiredProperties

### DIFF
--- a/src/cdn_definitions/schema.json
+++ b/src/cdn_definitions/schema.json
@@ -297,22 +297,5 @@
             "type": "string"
         }
     },
-    "requiredProperties": [
-        "version",
-        "rhui_alias",
-        "origin_alias",
-        "symlink_exceptions",
-        "release_stream_mappings",
-        "env_to_releasever_mappings",
-        "cfme_version_mappings",
-        "tps_variant_mappings",
-        "filter_arch_from_releases",
-        "override_initial_rhel_release",
-        "signing_keys_mappings",
-        "rhui_product_id",
-        "ignore_lp_version_product_ids",
-        "exclude_from_listings",
-        "populate_ubi_dot_repos"
-    ],
     "type": "object"
 }

--- a/src/cdn_definitions/schema.yaml
+++ b/src/cdn_definitions/schema.yaml
@@ -261,21 +261,4 @@ properties:
   populate_ubi_dot_repos:
     type: boolean
 
-requiredProperties:
-- version
-- rhui_alias
-- origin_alias
-- symlink_exceptions
-- release_stream_mappings
-- env_to_releasever_mappings
-- cfme_version_mappings
-- tps_variant_mappings
-- filter_arch_from_releases
-- override_initial_rhel_release
-- signing_keys_mappings
-- rhui_product_id
-- ignore_lp_version_product_ids
-- exclude_from_listings
-- populate_ubi_dot_repos
-
 additionalProperties: false


### PR DESCRIPTION
The schema here attempted to require certain properties, but this had no
effect because the correct keyword is "required", not
"requiredProperties". This can be confirmed at
http://json-schema.org/draft-07/schema.

So, in reality we have never required any properties here.
We could now change this to "required" to match the original intent,
but I think it's reasonable to just drop them instead since:

- adding new required properties is backwards-incompatible. In the
  worst-case scenario it breaks some services; in the best case it
  probably breaks at least some tests.

- it anyway seems more user-friendly to allow these fields to be
  omitted, since they always have some obvious default value
  which could be provided (such as an empty list or dict). These could
  even be filled in by the library automatically on load, though this
  is not pursued at the moment.