### PR TITLE
Nominate additional CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @rohanpm @rbikar
+*   @rohanpm @rbikar @crungehottman


### PR DESCRIPTION
Three is the ideal number of owners while this project only had two.
I think it makes sense to add Caleigh here since she did various work
in this area, and due to the connection with exodus projects.