### PR TITLE
Constrain py27 install of jsonschema to v3.2.0

### DIFF
--- a/constraints-legacy.txt
+++ b/constraints-legacy.txt
@@ -1,3 +1,4 @@
 # Oldest supported versions of major libraries can be added to this
 # file. They'll be tested with Python 2.7.
 pyrsistent==0.16.1
+jsonschema==3.2.0


### PR DESCRIPTION
jsonschema dropped support for python2 in v4.0.1 [1], and v4.0.0
was yanked [2]. jsonschema-3.2.0 is the latest release that contains
py27 support.

[1] https://github.com/Julian/jsonschema/releases/tag/v4.0.1
[2] https://pypi.org/project/jsonschema/4.0.0/