### PR TITLE
Added mapping for final releasever override [RHELDST-19153]

### DIFF
--- a/src/cdn_definitions/data.json
+++ b/src/cdn_definitions/data.json
@@ -43,6 +43,9 @@
             "src": "/origin/rpm"
         }
     ],
+    "override_final_rhel_release": {
+        "cs_label_example": "0.0"
+    },
     "override_initial_rhel_release": {
         "0": "0.0"
     },
@@ -77,26 +80,26 @@
     "repo_overrides": {
         "prod": [
             {
-                "key": "example",
                 "if_match_path": "/content/dist/rhel9/",
+                "key": "example",
                 "value": true
             },
             {
-                "key": "example",
                 "if_created_after": "2023-06-01T14:00:00Z",
                 "if_match_id": "rhel-8",
+                "key": "example",
                 "value": true
             }
         ],
         "stage": [
             {
-                "key": "example",
                 "if_match_id": ".",
+                "key": "example",
                 "value": true
             },
             {
-                "key": "example",
                 "if_match_id": "e2e.*rhel-8",
+                "key": "example",
                 "value": false
             }
         ]

--- a/src/cdn_definitions/data.yaml
+++ b/src/cdn_definitions/data.yaml
@@ -161,6 +161,10 @@ tps_variant_mappings:
 override_initial_rhel_release:
   "0": "0.0"
 
+# Workaround used to override the final RHEL version for given content set
+override_final_rhel_release:
+  "cs_label_example": "0.0"
+
 # Maps an architecture to RHEL versions that do not include said architecture.
 filter_arches_from_release:
   "0":

--- a/src/cdn_definitions/schema.json
+++ b/src/cdn_definitions/schema.json
@@ -44,6 +44,22 @@
             },
             "type": "object"
         },
+        "content_set_label": {
+            "pattern": "^[A-Za-z0-9_\\-]{1,200}$",
+            "type": "string"
+        },
+        "content_set_to_release_version_mapping": {
+            "additionalProperties": false,
+            "patternProperties": {
+                ".*": {
+                    "$ref": "#/definitions/release_version"
+                }
+            },
+            "propertyNames": {
+                "$ref": "#/definitions/content_set_label"
+            },
+            "type": "object"
+        },
         "current_latest_rhel_versions": {
             "additionalProperties": false,
             "patternProperties": {
@@ -221,10 +237,6 @@
                 }
             ],
             "properties": {
-                "key": {
-                    "minLength": 1,
-                    "type": "string"
-                },
                 "if_created_after": {
                     "$ref": "#/definitions/iso8601_datetime"
                 },
@@ -236,6 +248,10 @@
                 },
                 "if_match_path": {
                     "$ref": "#/definitions/absolute_path"
+                },
+                "key": {
+                    "minLength": 1,
+                    "type": "string"
                 },
                 "value": {
                     "type": [
@@ -348,6 +364,9 @@
         },
         "origin_alias": {
             "$ref": "#/definitions/path_alias_list"
+        },
+        "override_final_rhel_release": {
+            "$ref": "#/definitions/content_set_to_release_version_mapping"
         },
         "override_initial_rhel_release": {
             "$ref": "#/definitions/major_to_release_version_mapping"

--- a/src/cdn_definitions/schema.yaml
+++ b/src/cdn_definitions/schema.yaml
@@ -45,6 +45,10 @@ definitions:
     type: string
     pattern: "^[0-9]+$"
 
+  content_set_label:
+    type: string
+    pattern: "^[A-Za-z0-9_\\-]{1,200}$"
+
   product_id_list:
     type: array
     items:
@@ -81,6 +85,15 @@ definitions:
     type: object
     propertyNames:
       $ref: "#/definitions/major_version_string"
+    patternProperties:
+      ".*":
+        $ref: "#/definitions/release_version"
+    additionalProperties: false
+
+  content_set_to_release_version_mapping:
+    type: object
+    propertyNames:
+      $ref: "#/definitions/content_set_label"
     patternProperties:
       ".*":
         $ref: "#/definitions/release_version"
@@ -290,6 +303,9 @@ properties:
 
   override_initial_rhel_release:
     $ref: "#/definitions/major_to_release_version_mapping"
+
+  override_final_rhel_release:
+    $ref: "#/definitions/content_set_to_release_version_mapping"
 
   filter_arches_from_release:
     $ref: "#/definitions/version_to_arch_list_mapping"


### PR DESCRIPTION
Added support for definition of override for final releasever
by content set label.

Additionally the pre-commit re-organized json files a bit.