### PR TITLE
Remove coverage upload to Codecov

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,13 +33,6 @@ jobs:
         run: pip install tox
       - name: Run Tox
         run: tox -e cov
-      - name: Install pytest cov
-        run: pip install pytest-cov
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          fail_ci_if_error: true
-          verbose: true
   docs:
     runs-on: ubuntu-latest
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -26,21 +26,7 @@ deps=
 	pytest-cov
 usedevelop=true
 commands=
-	pytest --cov-report=html --cov=cdn_definitions {posargs}
-
-[testenv:cov-travis]
-passenv =
-  TRAVIS
-  TRAVIS_*
-deps=
-        -rrequirements.txt
-	-rtest-requirements.txt
-	pytest-cov
-	coveralls
-usedevelop=true
-commands=
-	pytest --cov=cdn_definitions {posargs}
-	coveralls
+	pytest --cov-report=html --cov=cdn_definitions --cov-fail-under=100 {posargs}
 
 [testenv:docs]
 deps=


### PR DESCRIPTION
Upload to Codecov fails without a token from
the forks and also enforced rate limiting.
Hence, remove the upload to Codecov. Instead,
configure the pytest failure on coverage below
100% for the tox cov jobs.