### PR TITLE
Convert RHUI product ID to list of IDs [RHELDST-28614]

### DIFF
--- a/src/cdn_definitions/schema.json
+++ b/src/cdn_definitions/schema.json
@@ -454,6 +454,9 @@
         "rhui_product_id": {
             "$ref": "#/definitions/product_id"
         },
+        "rhui_product_ids": {
+            "$ref": "#/definitions/product_id_list"
+        },
         "signing_keys_mappings": {
             "$ref": "#/definitions/signing_keys_mapping"
         },

--- a/src/cdn_definitions/schema.yaml
+++ b/src/cdn_definitions/schema.yaml
@@ -361,6 +361,9 @@ properties:
   rhui_product_id:
     $ref: "#/definitions/product_id"
 
+  rhui_product_ids:
+    $ref: "#/definitions/product_id_list"
+
   ignore_lp_version_product_ids:
     $ref: "#/definitions/product_id_list"
 


### PR DESCRIPTION
Recently created rhui tooling products and content sets caused issues for downstream tools, such as Manifest-API.  This is because their download_urls contained "/rhui", which erroneously set the for_rhui property to true.

This issue has been fixed, but we would like to extend the solution to make it more robust. This change adds a new rhui_product_ids entry to the schema, so we can compare against a list of IDs rather than a single one. This was done to avoid breaking changes.