### PR TITLE
Convert RHUI product ID to list of IDs [RHELDST-28614]

### DIFF
--- a/src/cdn_definitions/data.json
+++ b/src/cdn_definitions/data.json
@@ -235,7 +235,10 @@
             "src": "/content/rc/rhel/rhui"
         }
     ],
-    "rhui_product_id": "000",
+    "rhui_product_ids": [
+        "000",
+        "001"
+    ],
     "signing_keys_mappings": {
         "default": {
             "beta_keys": [

--- a/src/cdn_definitions/data.yaml
+++ b/src/cdn_definitions/data.yaml
@@ -178,7 +178,11 @@ ignore_lp_version_product_ids:
 - "000"
 
 # The RHUI product ID. Used to identify RHUI repos that do not contain the 'rhui' substring.
-rhui_product_id: "000"
+# This value supersedes 'rhui_product_id', which only allowed a single string and should
+# now be considered as deprecated.
+rhui_product_ids:
+- "000"
+- "001"
 
 # Maps a major RHEL version (platform_major_version), a layered product, or a platform to a list
 # of acceptable GA signing keys (ga_keys) and (optional) beta signing keys (beta_keys). The

--- a/src/cdn_definitions/schema.json
+++ b/src/cdn_definitions/schema.json
@@ -454,6 +454,9 @@
         "rhui_product_id": {
             "$ref": "#/definitions/product_id"
         },
+        "rhui_product_ids": {
+            "$ref": "#/definitions/product_id_list"
+        },
         "signing_keys_mappings": {
             "$ref": "#/definitions/signing_keys_mapping"
         },

--- a/src/cdn_definitions/schema.yaml
+++ b/src/cdn_definitions/schema.yaml
@@ -361,6 +361,9 @@ properties:
   rhui_product_id:
     $ref: "#/definitions/product_id"
 
+  rhui_product_ids:
+    $ref: "#/definitions/product_id_list"
+
   ignore_lp_version_product_ids:
     $ref: "#/definitions/product_id_list"
 


### PR DESCRIPTION
Recently created rhui tooling products and content sets caused issues for downstream tools, such as Manifest-API.  This is because their download_urls contained "/rhui", which erroneously set the for_rhui property to true.

This issue has been fixed, but we would like to extend the solution to make it more robust. This change adds a new rhui_product_ids entry to the schema, so we can compare against a list of IDs rather than a single one. This was done to avoid breaking changes.