### PR TITLE
Make repo content sync configurable [RHELDST-34407]

### DIFF
--- a/src/cdn_definitions/data.json
+++ b/src/cdn_definitions/data.json
@@ -99,7 +99,6 @@
     "override_initial_rhel_release": {
         "0": "0.0"
     },
-    "populate_ubi_dot_repos": true,
     "release_stream_mappings": {
         "aus": [
             "0.0"
@@ -127,6 +126,28 @@
             "src": "/content/dist/rhel1/1"
         }
     ],
+    "repo_content_sync": {
+        "prod": [
+            {
+                "populate_dot_repos": false,
+                "source": "https://example.com/ubi/data"
+            },
+            {
+                "populate_dot_repos": true,
+                "source": "https://example.com/client-tools/data"
+            }
+        ],
+        "stage": [
+            {
+                "populate_dot_repos": false,
+                "source": "https://example.com/ubi/data"
+            },
+            {
+                "populate_dot_repos": true,
+                "source": "https://example.com/client-tools/data"
+            }
+        ]
+    },
     "repo_overrides": {
         "prod": [
             {

--- a/src/cdn_definitions/data.yaml
+++ b/src/cdn_definitions/data.yaml
@@ -222,9 +222,26 @@ exclude_from_listings:
 rhel_open_dist:
 - 0
 
-# If set to False, ubi_population repo note will be set False for all ubi DOT repos and
-# no ubi DOT repo will be populated.
-populate_ubi_dot_repos: True
+# repo_content_sync configures selective content synchronization from RHEL repos to other products.
+# It is used e.g. by UBI to sync content to Public CDN.
+repo_content_sync:
+  stage:
+  # Source git repo contains the configuration for tooling that facilitates
+  # the repo content sync (currently ubipop).
+  # The configuration includes content set labels and lists with allowed and blocked packages.
+  - source: https://example.com/ubi/data
+    # If set to False, ubi_population repo note will be set False for all DOT repos and
+    # no output DOT repo belonging under the content set defined in the source git repo
+    # will be populated. Only the mainline repos will be populated. If set to True, all DOT repos
+    # will be populated alongside the mainline repos.
+    populate_dot_repos: False
+  - source: https://example.com/client-tools/data
+    populate_dot_repos: True
+  prod:
+  - source: https://example.com/ubi/data
+    populate_dot_repos: False
+  - source: https://example.com/client-tools/data
+    populate_dot_repos: True
 
 # repo_overrides can be used to define mappings between certain criteria matching CDN repos
 # and configuration which should be set on those repos. The intended usage is to allow

--- a/src/cdn_definitions/schema.json
+++ b/src/cdn_definitions/schema.json
@@ -261,6 +261,30 @@
             "type": "array",
             "uniqueItems": true
         },
+        "repo_content_sync": {
+            "additionalProperties": false,
+            "patternProperties": {
+                ".*": {
+                    "items": {
+                        "$ref": "#/definitions/repo_content_sync_record"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "repo_content_sync_record": {
+            "additionalProperties": false,
+            "properties": {
+                "populate_dot_repos": {
+                    "type": "boolean"
+                },
+                "source": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "repo_override": {
             "additionalProperties": false,
             "allOf": [
@@ -441,6 +465,9 @@
         },
         "releasever_alias": {
             "$ref": "#/definitions/path_alias_list"
+        },
+        "repo_content_sync": {
+            "$ref": "#/definitions/repo_content_sync"
         },
         "repo_overrides": {
             "$ref": "#/definitions/repo_overrides"

--- a/src/cdn_definitions/schema.yaml
+++ b/src/cdn_definitions/schema.yaml
@@ -270,6 +270,24 @@ definitions:
           $ref: "#/definitions/repo_override"
     additionalProperties: false
 
+  repo_content_sync_record:
+    type: object
+    properties:
+      source:
+        type: string
+      populate_dot_repos:
+        type: boolean
+    additionalProperties: false
+
+  repo_content_sync:
+    type: object
+    patternProperties:
+      ".*":
+        type: array
+        items:
+          $ref: "#/definitions/repo_content_sync_record"
+    additionalProperties: false
+
   directory_layout:
     type: object
     properties:
@@ -358,6 +376,7 @@ properties:
   rhel_open_dist:
     $ref: "#/definitions/major_version_list"
 
+  # Deprecated by rhui_product_ids
   rhui_product_id:
     $ref: "#/definitions/product_id"
 
@@ -370,8 +389,12 @@ properties:
   exclude_from_listings:
     $ref: "#/definitions/exclude_versions_from_listings"
 
+  # Deprecated by repo_content_sync
   populate_ubi_dot_repos:
     type: boolean
+
+  repo_content_sync:
+    $ref: "#/definitions/repo_content_sync"
 
   repo_overrides:
     $ref: "#/definitions/repo_overrides"


### PR DESCRIPTION
Currently, the configuration of the source repositories for content sync from RHEL to UBI is hardcoded in cdn-utils, and the same goes also for Client Tools. This makes any addition of more synced content difficult, as it requires tooling changes and deployment each time.

Additionally, `populate_ubi_dot_repos` isn't flexible enough because it doesn't allow for selective control over which products have their content populated in the DOT repos and in which environments.

This commit adds `repo_content_sync` configuration that allows to set the content synchronization per-environment. It accepts a list of git repo paths containing the configuration for tooling that facilitates the repo content sync (currently ubipop) and a flag that controls DOT repo population per-source.