### PR TITLE
Do not pin python for release/deploy to PyPI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,16 +9,16 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v6
         with:
-          python-version: 3.8
+          python-version: '3.13'
       - name: Install Setuptools
         run: pip install setuptools wheel
       - name: Build Package
         run: python setup.py sdist bdist_wheel
       - name: Publish package to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@release/v1.13
         with:
           password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
- old python versions do not handle correctly `-` in names, failing to deploy in PyPI. Newer version will replace these with `_`.